### PR TITLE
Fix line sewing behavior in orienteering route planner.

### DIFF
--- a/planner/orienteering_router.py
+++ b/planner/orienteering_router.py
@@ -214,7 +214,7 @@ class OrienteeringRouter:
                 %s)
         )
         SELECT
-            ST_AsGeoJSON(ST_LineMerge(ST_Union(the_geom))) AS geojson, 
+            ST_AsGeoJSON(ST_MakeLine(CASE WHEN node = source THEN the_geom ELSE ST_Reverse(the_geom) END)) AS geojson, 
             SUM(ways.length_m) AS length
         FROM dijkstra
           JOIN ways ON dijkstra.edge = ways.gid;


### PR DESCRIPTION
We build the final LineString by combining segments in the planned route.
It is important that we check the direct of travel, i.e. source -> target vs.
target -> source when building the final LineString, to avoid teleportation.

Fixes #4